### PR TITLE
change directed graph detection in generate_dendrogram

### DIFF
--- a/community/community_louvain.py
+++ b/community/community_louvain.py
@@ -262,7 +262,7 @@ def generate_dendrogram(graph, part_init=None, weight='weight', resolution=1.):
     :param weight:
     :type weight:
     """
-    if type(graph) != nx.Graph:
+    if graph.is_directed():
         raise TypeError("Bad graph type, use only non directed graph")
 
     # special case, when there is no link


### PR DESCRIPTION
The condition that the graph is a nx.Graph is too restrictive. It does
not allow to process a graph object that inherits from the nx.Graph
class. It can be replaced by a simple test to check if the graph is
directed.