### PR TITLE
taking into account the node removal cost

### DIFF
--- a/community/community_louvain.py
+++ b/community/community_louvain.py
@@ -435,13 +435,15 @@ def __one_level(graph, status, weight_key, resolution, randomize):
             com_node = status.node2com[node]
             degc_totw = status.gdegrees.get(node, 0.) / (status.total_weight * 2.)  # NOQA
             neigh_communities = __neighcom(node, graph, status, weight_key)
+            remove_cost = - resolution * neigh_communities.get(com_node,0) + \
+                (status.degrees.get(com_node, 0.) - status.gdegrees.get(node, 0.)) * degc_totw
             __remove(node, com_node,
                      neigh_communities.get(com_node, 0.), status)
             best_com = com_node
             best_increase = 0
             for com, dnc in __randomly(neigh_communities.items(),
                                        randomize):
-                incr = resolution * dnc - \
+                incr = remove_cost + resolution * dnc - \
                        status.degrees.get(com, 0.) * degc_totw
                 if incr > best_increase:
                     best_increase = incr


### PR DESCRIPTION
In the function __one_level for each node we iterate over the possible communities. best_com and best_increase are computed to decide the best community for this node. However, best_increase is initialized with 0 which seems to be not correct since the removal of a node from its community may have positive or negative effect on modularity. We corrected this, according to the original paper by Blondel et al. "Fast unfolding of communities in large networks". On our tests it makes the relatively small difference but sometimes it's important.