### PR TITLE
Remove <2.0 for networkx from requirements.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-networkx<2.0.0
+networkx
 numpydoc


### PR DESCRIPTION
python-louvain works for networkx[all]
@taynaud 