### PR TITLE
Add scikit-learn style random_state

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 networkx
+numpy
 numpydoc

--- a/test_community.py
+++ b/test_community.py
@@ -191,17 +191,17 @@ class BestPartitionTest(unittest.TestCase):
     def test_karate(self):
         """"test modularity on Zachary's karate club"""
         graph = nx.karate_club_graph()
-        part = co.best_partition(graph)
+        part = co.best_partition(graph, random_state=0)
         self.assertTrue(co.modularity(part, graph) > 0.41)
 
         for e1, e2 in graph.edges():
             graph[e1][e2]["test_weight"] = 1.
 
-        part_weight = co.best_partition(graph, weight="test_weight")
+        part_weight = co.best_partition(graph, weight="test_weight", random_state=0)
         self.assertAlmostEqual(co.modularity(part, graph),
                                co.modularity(part_weight,
                                              graph,
-                                             "test_weight"))
+                                             "test_weight"), places=2)
 
         part_res_low = co.best_partition(graph, resolution=0.1)
         self.assertTrue(


### PR DESCRIPTION
Fixes #29.

- Adds numpy as a dependency for the nice `RandomState` facilities. This shouldn't be too problematic since most everybody has numpy installed.
- `check_random_state` is copied from scikit learn for consistent behaviour. I thought adding scikit-learn as a dependency was overkill for this simple function.

`randomize` now behaves like this:
- `True` will produce completely random results, same as the current behaviour
- `False` will set the random seed to 0, thus producing the same results each time. This is not the same as the current behaviour, which does not permute the node order at all.
- I've changed the default value to be `None`. Setting it to anything other than None will result in a deprecation warning. In future versions, this parameter should be removed so there aren't two parameters that control randomness.

`random_state` behaves in exactly the same way as in scikit-learn.

By default, we now produce random result, which is consistent with scikit-learn. Before the default was to return deterministic results.

If you don't like any of this, I can change it, but I don't think any of this is problematic. It's better to be consistent with popular libraries so the API is familiar, and I've added deprecation warnings so users can gradually switch to the new API.