### PR TITLE
Fix license handling

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,30 @@
+Copyright (c) 2009-2018, Thomas Aynaud <thomas.aynaud@lip6.fr>
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice,
+this list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation
+and/or other materials provided with the distribution.
+
+* Neither the name of the python-louvain Developers nor the names of its
+contributors may be used to endorse or promote products derived from this
+software without specific prior written permission.
+
+
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include LICENSE
+graft docs

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -120,9 +120,9 @@ License :
     this list of conditions and the following disclaimer in the documentation
     and/or other materials provided with the distribution.<br><br>
 
-    * Neither the name of the NetworkX Developers nor the names of its contributors
-    may be used to endorse or promote products derived from this software without
-    specific prior written permission.<br><br><br>
+    * Neither the name of the python-louvain Developers nor the names of its
+    contributors may be used to endorse or promote products derived from this
+    software without specific prior written permission.<br><br><br>
 
 
 


### PR DESCRIPTION
Fix the project name in the license, add a dedicated license file, and include that license file in sdists as the license requires.  Also include the documentation in sdists.