### PR TITLE
Replace RandomState.permutation with RandomState.shuffle

### DIFF
--- a/community/community_louvain.py
+++ b/community/community_louvain.py
@@ -473,7 +473,7 @@ def __one_level(graph, status, weight_key, resolution, random_state):
         modified = False
         nb_pass_done += 1
 
-        for node in random_state.permutation(list(graph.nodes())):
+        for node in __randomize(graph.nodes(), random_state):
             com_node = status.node2com[node]
             degc_totw = status.gdegrees.get(node, 0.) / (status.total_weight * 2.)  # NOQA
             neigh_communities = __neighcom(node, graph, status, weight_key)
@@ -483,7 +483,7 @@ def __one_level(graph, status, weight_key, resolution, random_state):
                      neigh_communities.get(com_node, 0.), status)
             best_com = com_node
             best_increase = 0
-            for com, dnc in random_state.permutation(list(neigh_communities.items())):
+            for com, dnc in __randomize(neigh_communities.items(), random_state):
                 incr = remove_cost + resolution * dnc - \
                        status.degrees.get(com, 0.) * degc_totw
                 if incr > best_increase:
@@ -544,3 +544,10 @@ def __modularity(status):
         if links > 0:
             result += in_degree / links - ((degree / (2. * links)) ** 2)
     return result
+
+
+def __randomize(items, random_state):
+    """Returns a List containing a random permutation of items"""
+    randomized_items = list(items)
+    random_state.shuffle(randomized_items)
+    return randomized_items

--- a/test_community.py
+++ b/test_community.py
@@ -6,8 +6,10 @@ import unittest
 import random
 
 import networkx as nx
+import numpy
 
 import community as co
+from community.community_louvain import __randomize as randomize
 
 
 def girvan_graphs(zout):
@@ -309,6 +311,44 @@ class GenerateDendrogramTest(unittest.TestCase):
                              for node, comnode in part_1.items()
                              if comnode == com]
                 self.assertEqual(len(set(comhigher)), 1)
+
+
+class RandomizeTest(unittest.TestCase):
+    """Test the __randomize utility function"""
+
+    def test_randomize_handles_list_items(self):
+        """Test that Lists are randomized correctly"""
+        l = list(range(100))
+        random_state = numpy.random.RandomState()
+        randomized_items = randomize(l, random_state)
+        self.assertNotEqual(l, randomized_items, "List was not randomized")
+        self.assertEqual(set(l), set(randomized_items),
+                         "Input items and randomized items are not equal sets")
+        self.assertEqual(sorted(l), l, "Input list was changed")
+
+    def test_randomize_handles_dict_items(self):
+        """Test that Dict#items() are randomized correctly"""
+        d = {"1": 1, 2: 2, "3": "3"}
+        random_state = numpy.random.RandomState()
+        randomized_items = randomize(d.items(), random_state)
+        self.assertEqual(set(d.items()), set(randomized_items),
+                         "Input items and randomized items are not equal sets")
+
+    def test_randomize_handles_mixed_items(self):
+        """Test that Lists of mixed types are randomized correctly"""
+        random_state = numpy.random.RandomState()
+        items = [True, 1, 1.0, lambda x: 1, (2,), "test"]
+        randomized_items = randomize(items, random_state)
+        self.assertEqual(set(items), set(randomized_items),
+                         "Input items and randomized items are not equal sets")
+
+    def test_randomize_handles_iterators(self):
+        """Test that Iterators are randomized correctly"""
+        it = iter(range(10))
+        random_state = numpy.random.RandomState()
+        randomized_items = randomize(it, random_state)
+        self.assertEqual(set(range(10)), set(randomized_items),
+                         "Input items and randomized items are not equal sets")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
resolves #35

This change addresses 2 problems with RandomState.permutation:
(1) it's slow due to unncessary allocation, copy and conversions
(2) it munges mixed-type iterables, turning iterables of Tuples
    to nested arrays and converting all values to a common type

## Performance

I tested this fix with the [web-Google network from snap](https://snap.stanford.edu/data/web-Google.html). This network has 875k nodes and 5.1M edges. Here is the test code:

```python
import networkx
import community
import cProfile
import pickle


def test_community(graph, random_seed):
    profile = cProfile.Profile()
    profile.enable()

    best_part = community.best_partition(graph, random_state=random_seed)

    profile.disable()
    profile.dump_stats("profile_new2.log")

    with open('new2.pickle', 'wb') as f:
        pickle.dump(best_part, f)


if __name__ == '__main__':
    g = networkx.read_edgelist("web-Google.txt", nodetype=int)

    print("nodes %d" % len(g))

    test_community(g, 123)
```
Here are the results for Python 2 and Python 3 as tested on Ubuntu 18.04.2 LTS.

Version | Before | After
------- | ------ | -----
3.6.7 | 2579s | 732s
2.7.15rc1 | 1735s | 615s

## Correctness

In addition to the unit tests, the following script was used to ensure that results were identical to current master (the pickle files are generated by the above test script):

```python
import pickle
import sys

if __name__ == '__main__':
    old_pickle_file, new_pickle_file = sys.argv[1:]
    old_result = pickle.load(open(old_pickle_file, "rb"))
    new_result = pickle.load(open(new_pickle_file, "rb"))
    assert old_result == new_result
```
