### PR TITLE
Stop relabelling stable partitions

### DIFF
--- a/community/community_louvain.py
+++ b/community/community_louvain.py
@@ -421,18 +421,20 @@ def induced_graph(partition, graph, weight="weight"):
 def __renumber(dictionary):
     """Renumber the values of the dictionary from 0 to n
     """
-    count = 0
-    ret = dictionary.copy()
-    new_values = dict([])
+    values = set(dictionary.values())
+    target = set(range(len(values)))
 
-    for key in dictionary.keys():
-        value = dictionary[key]
-        new_value = new_values.get(value, -1)
-        if new_value == -1:
-            new_values[value] = count
-            new_value = count
-            count += 1
-        ret[key] = new_value
+    if values == target:
+        # no renumbering necessary
+        ret = dictionary.copy()
+    else:
+        # add the values that won't be renumbered
+        renumbering = dict(zip(target.intersection(values),
+                               target.intersection(values)))
+        # add the values that will be renumbered
+        renumbering.update(dict(zip(values.difference(target),
+                                    target.difference(values))))
+        ret = {k: renumbering[v] for k, v in dictionary.items()}
 
     return ret
 

--- a/test_community.py
+++ b/test_community.py
@@ -9,7 +9,7 @@ import networkx as nx
 import numpy
 
 import community as co
-from community.community_louvain import __randomize as randomize
+from community.community_louvain import __randomize as randomize, __renumber as renumber
 
 
 def girvan_graphs(zout):
@@ -369,6 +369,20 @@ class RandomizeTest(unittest.TestCase):
         self.assertEqual(set(range(10)), set(randomized_items),
                          "Input items and randomized items are not equal sets")
 
+
+class RenumberTest(unittest.TestCase):
+    """Test the __renumber utility function"""
+
+    def test_renumber_unchanged(self):
+        """Test that a partition is not renumbered unnecessarily"""
+        in_dict = {0: 1, 1: 0}
+        self.assertEqual(in_dict, renumber(in_dict))
+
+    def test_renumber_changed(self):
+        """Test that a partition is changed when necessary"""
+        in_dict = {0: 0, 1: 3, 2: 4, 3: 6}
+        expected_dict = {0: 0, 1: 3, 2: 1, 3: 2}
+        self.assertEqual(expected_dict, renumber(in_dict))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Calling `best_partition(graph, partition=stable)` where `stable`
is a stable partition has a high probability of returning a
permutation of `stable`. This can be prevented in
`community_louvain.__renumber(partition)` by first checking
that `partition` is valid i.e. has labels 0 to n, and if so not
renumbering.

An example of the current undesired behavior:
```
>>> import community
>>> in_dict = {0:1, 1:0}
>>> out_dict = community.community_louvain.__renumber(in_dict)
>>> in_dict == out_dict
False
```