### PR TITLE
fix test karate for networkx<=2.7

### DIFF
--- a/test_community.py
+++ b/test_community.py
@@ -203,7 +203,7 @@ class BestPartitionTest(unittest.TestCase):
         self.assertAlmostEqual(co.modularity(part, graph),
                                co.modularity(part_weight,
                                              graph,
-                                             "test_weight"), places=2)
+                                             "test_weight"), places=1)
 
         part_res_low = co.best_partition(graph, resolution=0.1)
         self.assertTrue(


### PR DESCRIPTION
In [Nixpkgs](https://github.com/NixOS/nixpkgs/) we are seeing a test failure for python-louvain, that got introduced when we updated networkx from 2.6.3 to 2.7:

```
...
test_renumber_changed (test_community.RenumberTest)             
Test that a partition is changed when necessary ... ok     
test_renumber_unchanged (test_community.RenumberTest)
Test that a partition is not renumbered unnecessarily ... ok
                       
======================================================================                                
FAIL: test_karate (test_community.BestPartitionTest)                                             
"test modularity on Zachary's karate club                    
----------------------------------------------------------------------     
Traceback (most recent call last):                                                                    
  File "/tmp/nix-build-python3.9-python-louvain-0.16.drv-0/python-louvain-0.16/test_community.py", line 203, in test_karate
    self.assertAlmostEqual(co.modularity(part, graph),
AssertionError: 0.44490358126721763 != 0.4155982905982906 within 2 places (0.02930529066892701 difference)
                                                   
----------------------------------------------------------------------                                                                                                                                                              
Ran 26 tests in 1.973s                                                                                                                                                                                                              
                                                                                                                                                                                                                                    
FAILED (failures=1)                                                                                                                                                                                                                 
Test failed: <unittest.runner.TextTestResult run=26 errors=0 failures=1>                                                                                                                                                            
error: Test failed: <unittest.runner.TextTestResult run=26 errors=0 failures=1>
```