### PR TITLE
Fix tests on Python 3.12

### DIFF
--- a/test_community.py
+++ b/test_community.py
@@ -61,7 +61,7 @@ class ModularityTest(unittest.TestCase):
             graph = nx.erdos_renyi_graph(50, 0.1)
             part = dict([])
             for node in graph:
-                part[node] = random.randint(0, self.number_of_tests / 10)
+                part[node] = random.randint(0, self.number_of_tests // 10)
             mod = co.modularity(part, graph)
             self.assertGreaterEqual(mod, -1)
             self.assertLessEqual(mod, 1)


### PR DESCRIPTION
At one place there is float division somewhere where Python expects integer, and Python 3.12 started failing on that.

I fixed the tests, but I wonder whether division was really your intention, because the affected random number has just two choices (upper bound is inclusive in this case, which confused me moments ago).